### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@ A Model Context Protocol (MCP) server that enables GitHub Copilot and other LLMs
 [![npm version](https://badge.fury.io/js/mcp-oracle-database.svg)](https://www.npmjs.com/package/mcp-oracle-database)
 [![License: ISC](https://img.shields.io/badge/License-ISC-blue.svg)](https://opensource.org/licenses/ISC)
 
+<a href="https://glama.ai/mcp/servers/@tannerpace/mcp-oracle-database">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@tannerpace/mcp-oracle-database/badge" alt="Oracle Database Server MCP server" />
+</a>
+
 ## 📦 Installation
 
 ### From npm (Recommended)
@@ -461,4 +465,3 @@ ISC
 ## Contributing
 
 Contributions welcome! Please open an issue or pull request.
-


### PR DESCRIPTION
This PR adds a badge for the [Oracle Database MCP Server](https://glama.ai/mcp/servers/@tannerpace/mcp-oracle-database) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@tannerpace/mcp-oracle-database">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@tannerpace/mcp-oracle-database/badge" alt="Oracle Database Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.